### PR TITLE
Update GitHub checkout action and fix the docker-compose command

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the website
-      run: docker-compose run --rm middleman bundle exec middleman build
+      run: docker compose run --rm middleman bundle exec middleman build


### PR DESCRIPTION
Fix the GitHub action to use the latest checkout version and the right docker compose command.